### PR TITLE
Defines a pattern for address and hex fields and a format

### DIFF
--- a/rollup.yaml
+++ b/rollup.yaml
@@ -289,6 +289,8 @@ components:
           type: string
           description: 20-byte address of the account that submitted the input.
           example: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+          pattern: "^0x([0-9a-fA-F]{40})$"
+          format: address
         epoch_index:
           type: integer
           format: uint64
@@ -324,6 +326,8 @@ components:
         For instance, '0xdeadbeef' corresponds to a payload with length 4 and bytes 222, 173, 190, 175.
         An empty payload is represented by the string '0x'.
       example: "0xdeadbeef"
+      pattern: "^0x([0-9a-fA-F]{2})*$"
+      format: hex
 
     Inspect:
       type: object
@@ -340,6 +344,8 @@ components:
           type: string
           description: 20-byte address of the destination contract for which the payload will be sent.
           example: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+          pattern: "^0x([0-9a-fA-F]{40})$"
+          format: address
         payload:
           type: string
           description: |


### PR DESCRIPTION
OpenAPI allows the definition of a [format](https://swagger.io/specification/#data-types) property.

It can container [any](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.2.3) aside from a few [standard](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.3.1) ones.

This will help the generation of code from the schema.
