### PR TITLE
Fix 202 response, which is in fact a text/plain

### DIFF
--- a/rollup.yaml
+++ b/rollup.yaml
@@ -112,6 +112,11 @@ paths:
 
         "202":
           description: Finish accepted but try again to obtain the next request.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "no rollup request available"
 
         default:
           description: Error response.


### PR DESCRIPTION
The host-runner is responding 202 with `Content-Type: text/plain` and a string like "no rollup request available".
This should be reflected in the API spec. Otherwise code generation tools don't handle it correctly.

As far as I understand the real rollups http server doesn't return 202. Or at least I couldn't find it.
