### PR TITLE
Add format hex to voucher payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unrelesed
 
+## [0.7.3] - 2024-04-17
+
+### Changed
+
+- Add format hex to voucher payload
+
 ## [0.7.2] - 2024-04-16
 
 ### Changed
@@ -75,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.2.0]
 - [0.1.0]
 
-[unreleased]: https://github.com/cartesi/openapi-interfaces/compare/v0.7.2...HEAD
+[unreleased]: https://github.com/cartesi/openapi-interfaces/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/cartesi/openapi-interfaces/releases/tag/v0.7.3
 [0.7.2]: https://github.com/cartesi/openapi-interfaces/releases/tag/v0.7.2
 [0.7.1]: https://github.com/cartesi/openapi-interfaces/releases/tag/v0.7.1
 [0.7.0]: https://github.com/cartesi/openapi-interfaces/releases/tag/v0.7.0

--- a/rollup.yaml
+++ b/rollup.yaml
@@ -366,6 +366,7 @@ components:
             by its ABI-encoded arguments.
             ref: https://docs.soliditylang.org/en/v0.8.19/abi-spec.html
           example: "0xcdcd77c000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001"
+          format: hex
       required:
         - destination
         - payload


### PR DESCRIPTION
The format field is used by tools to generate better typed structures.

One of these tools is the one uses by [deroll](https://github.com/tuler/deroll/blob/4c8cf16cb9886beb98c844ca1e52ef7b60072d18/packages/core/schema.ts#L21)